### PR TITLE
fix: コードブロック付きの記事がNodeが見つからないことによりリロード時にエラーとなる事象を修正

### DIFF
--- a/app/routes/posts.$slug.tsx
+++ b/app/routes/posts.$slug.tsx
@@ -166,7 +166,7 @@ export default function PostSlug() {
               </div>
             );
           }
-          if(domNode.name === 'code' && domNode.children[0].nodeType === Node.TEXT_NODE) {
+          if(domNode.name === 'code' && domNode.children[0].nodeType === 3) {
             const textNode = domNode.children[0];
             const result = hljs.highlightAuto(textNode.data);
             const dom = parse(result.value);    


### PR DESCRIPTION
もともとシンタックスハイライト部分の調整のためにNodeという定数を使っていたが、これが見つからないことでエラーになっていた。マジックナンバーではあるが、CMSを変える可能性等もあるため、暫定的にこの対応をした。
